### PR TITLE
Added snackbar support like standard design lib version of FAB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.1.0'
+    classpath 'com.android.tools.build:gradle:2.2.2'
 
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Nov 27 11:18:21 CET 2014
+#Thu Nov 17 15:00:32 EST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,6 +21,7 @@ android {
 
 dependencies {
   compile 'com.android.support:support-annotations:22.2.0'
+  compile 'com.android.support:design:22.2.0'
 }
 
 apply from: './gradle-mvn-push.gradle'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 22
-  buildToolsVersion "22.0.1"
+  compileSdkVersion = 25
+  buildToolsVersion = "25"
 
   defaultConfig {
     minSdkVersion 14
-    targetSdkVersion 22
+    targetSdkVersion 25
     versionName project.VERSION_NAME
     versionCode Integer.parseInt(project.VERSION_CODE)
     consumerProguardFiles 'consumer-proguard-rules.pro'
@@ -20,8 +20,8 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:support-annotations:22.2.0'
-  compile 'com.android.support:design:22.2.0'
+  compile 'com.android.support:support-annotations:25.0.1'
+  compile 'com.android.support:design:25.0.1'
 }
 
 apply from: './gradle-mvn-push.gradle'

--- a/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionButton.java
+++ b/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionButton.java
@@ -25,6 +25,7 @@ import android.support.annotation.DimenRes;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
+import android.support.design.widget.CoordinatorLayout;
 import android.util.AttributeSet;
 import android.widget.ImageButton;
 import android.widget.TextView;
@@ -32,6 +33,7 @@ import android.widget.TextView;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+@CoordinatorLayout.DefaultBehavior(FloatingActionButtonSnackbarBehavior.class)
 public class FloatingActionButton extends ImageButton {
 
   public static final int SIZE_NORMAL = 0;

--- a/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionButtonSnackbarBehavior.java
+++ b/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionButtonSnackbarBehavior.java
@@ -1,0 +1,90 @@
+package com.getbase.floatingactionbutton;
+
+import android.content.Context;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.design.widget.Snackbar;
+import android.support.v4.view.ViewCompat;
+import android.support.v4.view.animation.FastOutSlowInInterpolator;
+import android.util.AttributeSet;
+import android.view.View;
+
+import java.util.List;
+
+/**
+ * Layout behavior that can be applied to either {@link FloatingActionButton} or {@link FloatingActionsMenu}
+ * to make components automatically animate to stay above {@code Snackbar} instances within the
+ * same parent {@code CoordinatorLayout}.
+ * <p>
+ * Usage:
+ * <pre>
+ * &lt;android.support.design.widget.CoordinatorLayout ...&gt;
+ *   ...
+ *   &lt;com.getbase.floatingactionbutton.FloatingActionsMenu
+ *     ...
+ *     app:layout_behavior="com.getbase.floatingactionbutton.FloatingActionButtonSnackbarBehavior" /&gt;
+ * &lt;/android.support.design.widget.CoordinatorLayout&gt;
+ * </pre>
+ */
+public class FloatingActionButtonSnackbarBehavior extends CoordinatorLayout.Behavior<View> {
+
+    private float mTranslationY;
+
+    @SuppressWarnings("unused")
+    public FloatingActionButtonSnackbarBehavior() {
+        super();
+    }
+
+    @SuppressWarnings("unused")
+    public FloatingActionButtonSnackbarBehavior(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    /**
+     * Find the {@code translation Y} value for any child Snackbar components.
+     *
+     * @return 0.0F if there are no Snackbar components found, otherwise returns the min offset
+     * that the FAB component should be animated.
+     */
+    private float getFabTranslationYForSnackbar(CoordinatorLayout parent, View fab) {
+        float minOffset = 0.0F;
+        final List<View> dependencies = parent.getDependencies(fab);
+
+        for (View view : dependencies) {
+            if (view instanceof Snackbar.SnackbarLayout && parent.doViewsOverlap(fab, view)) {
+                minOffset = Math.min(minOffset, ViewCompat.getTranslationY(view) - (float) view.getHeight());
+            }
+        }
+
+        return minOffset;
+    }
+
+    @Override
+    public boolean layoutDependsOn(CoordinatorLayout parent, View child, View dependency) {
+        return dependency instanceof Snackbar.SnackbarLayout;
+    }
+
+    @Override
+    public boolean onDependentViewChanged(CoordinatorLayout parent, View child, View dependency) {
+        if (dependency instanceof Snackbar.SnackbarLayout) {
+            this.updateFabTranslationForSnackbar(parent, child, dependency);
+        }
+        return false;
+    }
+
+    /**
+     * Animate FAB on snackbar change.
+     */
+    private void updateFabTranslationForSnackbar(CoordinatorLayout parent, View fab, View snackbar) {
+        final float translationY = getFabTranslationYForSnackbar(parent, fab);
+        if (translationY != this.mTranslationY) {
+            ViewCompat.animate(fab).cancel();
+            if (Math.abs(translationY - this.mTranslationY) == (float) snackbar.getHeight()) {
+                ViewCompat.animate(fab).translationY(translationY).setInterpolator(new FastOutSlowInInterpolator());
+            } else {
+                ViewCompat.setTranslationY(fab, translationY);
+            }
+
+            this.mTranslationY = translationY;
+        }
+    }
+}

--- a/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionsMenu.java
+++ b/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionsMenu.java
@@ -14,6 +14,7 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.ColorRes;
 import android.support.annotation.NonNull;
+import android.support.design.widget.CoordinatorLayout;
 import android.util.AttributeSet;
 import android.view.ContextThemeWrapper;
 import android.view.TouchDelegate;
@@ -24,6 +25,7 @@ import android.view.animation.Interpolator;
 import android.view.animation.OvershootInterpolator;
 import android.widget.TextView;
 
+@CoordinatorLayout.DefaultBehavior(FloatingActionButtonSnackbarBehavior.class)
 public class FloatingActionsMenu extends ViewGroup {
   public static final int EXPAND_UP = 0;
   public static final int EXPAND_DOWN = 1;

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 22
-  buildToolsVersion "22.0.1"
+  compileSdkVersion = 25
+  buildToolsVersion = "25"
 
   defaultConfig {
     applicationId "com.getbase.floatingactionbutton.sample"
     minSdkVersion 14
-    targetSdkVersion 22
+    targetSdkVersion 25
     versionCode 1
     versionName "1.0"
   }


### PR DESCRIPTION
This PR adds @PaulWoitaschek's code from https://github.com/futuresimple/android-floating-action-button/issues/209 to the repo, with some minor modifications:
- Improved docs
- Generic type changed to `View` instead of `FloatingActionButton`, this allows the behavior to be applied to both `FloatingActionButton` and `FloatingActionsMenu` elements
- Added as default behavior to both `FloatingActionButton` and `FloatingActionsMenu` via `@CoordinatorLayout.DefaultBehavior` annotation.

This applies the concept described in https://lab.getbase.com/introduction-to-coordinator-layout-on-android/, but the demo code from that post does not seem to work correctly.

Thanks to @PaulWoitaschek for his work on this! :100:
